### PR TITLE
Fix PDF duplicate sections

### DIFF
--- a/src/GlobalMindednessSurvey.jsx
+++ b/src/GlobalMindednessSurvey.jsx
@@ -344,6 +344,17 @@ const uiText = {
 
       drawBar(results.overallScore / results.overallMax, [54, 162, 235]);
 
+      const facetDescriptions = {
+        Responsibility:
+          "This facet captures a person's felt moral obligation toward people and problems beyond their own borders. Someone who scores high here experiences a \u201cdeep personal concern\u201d for global inequities and believes they ought to help relieve them, whether that means supporting human-rights campaigns, adjusting lifestyle choices to cut carbon, or advocating for fairer trade.",
+        CulturalPluralism:
+          'Global-minded individuals also prize diversity as an authentic good. The pluralism sub-scale gauges curiosity about unfamiliar customs, comfort with ambiguity, and the conviction that every culture \u201ccontributes something of value to the world.\u201d Rather than merely tolerating difference, it frames intercultural contact as a source of learning and mutual enrichment.',
+        Efficacy:
+          "Feeling responsible is only half the story; this dimension measures confidence that one\u2019s actions can matter. It taps an internalised sense of agency\u2014belief that writing to a legislator, mentoring a refugee, or changing consumption habits will, in aggregate, shift outcomes. High-efficacy respondents typically translate global concern into concrete initiatives because they assume their efforts are consequential.",
+        Interconnectedness:
+          'Finally, the scale explores how strongly a person perceives humanity\u2019s web of social, economic and ecological linkages. High scores reflect an \u201cappreciation for and awareness of the way in which all people from all nations are connected,\u201d from supply chains and digital media to shared climate systems and pandemics. This worldview encourages thinking in terms of ripple effects and mutual dependence rather than isolated national interests.',
+      };
+
       Object.entries(results.categoryScores)
         .filter(([key]) => !key.includes('Max'))
         .forEach(([category, score]) => {
@@ -359,7 +370,7 @@ const uiText = {
           y += 11;
           doc.setFontSize(9);
           const descLines = doc.splitTextToSize(
-            fullSurveyData.categoryDescriptions[language][category],
+            facetDescriptions[category],
             barWidth
           );
           doc.text(descLines, margin, y);
@@ -367,46 +378,6 @@ const uiText = {
           doc.setFontSize(11);
           drawBar(percentage, [34, 197, 94]);
         });
-
-      // Add detailed facet descriptions below on the same page
-      const facetMargin = margin;
-      let facetY = y;
-      const facetWidth = contentWidth;
-
-      const facets = [
-        {
-          title: 'Responsibility',
-          text:
-            "This facet captures a person\u2019s felt moral obligation toward people and problems beyond their own borders. Someone who scores high here experiences a \u201cdeep personal concern\u201d for global inequities and believes they ought to help relieve them, whether that means supporting human-rights campaigns, adjusting lifestyle choices to cut carbon, or advocating for fairer trade.",
-        },
-        {
-          title: 'Cultural Pluralism',
-          text:
-            'Global-minded individuals also prize diversity as an authentic good. The pluralism sub-scale gauges curiosity about unfamiliar customs, comfort with ambiguity, and the conviction that every culture \u201ccontributes something of value to the world.\u201d Rather than merely tolerating difference, it frames intercultural contact as a source of learning and mutual enrichment.',
-        },
-        {
-          title: 'Efficacy',
-          text:
-            "Feeling responsible is only half the story; this dimension measures confidence that one\u2019s actions can matter. It taps an internalised sense of agency\u2014belief that writing to a legislator, mentoring a refugee, or changing consumption habits will, in aggregate, shift outcomes. High-efficacy respondents typically translate global concern into concrete initiatives because they assume their efforts are consequential.",
-        },
-        {
-          title: 'Interconnectedness',
-          text:
-            'Finally, the scale explores how strongly a person perceives humanity\u2019s web of social, economic and ecological linkages. High scores reflect an \u201cappreciation for and awareness of the way in which all people from all nations are connected,\u201d from supply chains and digital media to shared climate systems and pandemics. This worldview encourages thinking in terms of ripple effects and mutual dependence rather than isolated national interests.',
-        },
-      ];
-
-      facets.forEach(({ title, text }) => {
-        doc.setFontSize(11);
-        doc.text(title, facetMargin, facetY);
-        facetY += 12;
-        doc.setFontSize(9);
-        const lines = doc.splitTextToSize(text, facetWidth);
-        doc.text(lines, facetMargin, facetY);
-        facetY += lines.length * 9 + 12;
-      });
-
-      y = facetY;
 
       doc.save('results.pdf');
     };


### PR DESCRIPTION
## Summary
- remove redundant facet section from PDF export
- show paragraph descriptions with category bars in results PDF

## Testing
- `npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_687519a826908323b999e25fc550af82