### PR TITLE
Add CSV and email export options to survey results

### DIFF
--- a/src/GlobalMindednessSurvey.jsx
+++ b/src/GlobalMindednessSurvey.jsx
@@ -206,6 +206,8 @@ const uiText = {
     overallScore: "Overall Score",
     categoryScores: "Category Scores:",
     downloadPdf: "Download PDF",
+    downloadCsv: "Download CSV",
+    emailResults: "Email Results",
     takeSurveyAgain: "Take Survey Again",
     question: "Question",
     of: "of",
@@ -221,6 +223,8 @@ const uiText = {
     overallScore: "总分",
     categoryScores: "分类得分：",
     downloadPdf: "下载 PDF",
+    downloadCsv: "下载 CSV",
+    emailResults: "通过电子邮件发送结果",
     takeSurveyAgain: "再次参与调查",
     question: "问题",
     of: "/",
@@ -236,6 +240,8 @@ const uiText = {
     overallScore: "Score total",
     categoryScores: "Scores par catégorie :",
     downloadPdf: "Télécharger le PDF",
+    downloadCsv: "Télécharger CSV",
+    emailResults: "Envoyer les résultats par e-mail",
     takeSurveyAgain: "Reprendre le sondage",
     question: "Question",
     of: "sur",
@@ -251,6 +257,8 @@ const uiText = {
     overallScore: "Puntuación total",
     categoryScores: "Puntuaciones por categoría:",
     downloadPdf: "Descargar PDF",
+    downloadCsv: "Descargar CSV",
+    emailResults: "Enviar resultados por correo",
     takeSurveyAgain: "Realizar la encuesta de nuevo",
     question: "Pregunta",
     of: "de",
@@ -381,6 +389,49 @@ const uiText = {
 
       doc.save('results.pdf');
     };
+
+    const downloadCsv = () => {
+      if (!results) return;
+
+      const rows = [
+        ['Metric', 'Score', 'Max'],
+        ['Overall', results.overallScore, results.overallMax],
+        ...Object.entries(results.categoryScores)
+          .filter(([key]) => !key.includes('Max'))
+          .map(([category, score]) => {
+            const max = results.categoryScores[`${category}Max`];
+            return [fullSurveyData.categoryLabels[language][category], score, max];
+          }),
+      ];
+
+      const csvContent = rows.map((r) => r.join(',')).join('\n');
+      const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.setAttribute('download', 'results.csv');
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    };
+
+    const emailResults = () => {
+      if (!results) return;
+
+      const subject = encodeURIComponent('Global Mindedness Survey Results');
+      const bodyLines = [
+        `${uiText[language].overallScore}: ${results.overallScore} / ${results.overallMax} (${results.interpretation})`,
+        ...Object.entries(results.categoryScores)
+          .filter(([key]) => !key.includes('Max'))
+          .map(([category, score]) => {
+            const max = results.categoryScores[`${category}Max`];
+            return `${fullSurveyData.categoryLabels[language][category]}: ${score} / ${max}`;
+          }),
+      ];
+      const body = encodeURIComponent(bodyLines.join('\n'));
+      window.location.href = `mailto:?subject=${subject}&body=${body}`;
+    };
   
     return (
       <div className="p-6 max-w-2xl mx-auto bg-white rounded-2xl shadow-xl mt-10 border border-gray-200">
@@ -442,6 +493,20 @@ const uiText = {
               onClick={downloadPdf}
             >
               {uiText[language].downloadPdf}
+            </button>
+
+            <button
+              className="mt-4 w-full bg-purple-600 hover:bg-purple-700 text-white text-xl py-3 rounded-2xl shadow-lg"
+              onClick={emailResults}
+            >
+              {uiText[language].emailResults}
+            </button>
+
+            <button
+              className="mt-4 w-full bg-yellow-500 hover:bg-yellow-600 text-white text-xl py-3 rounded-2xl shadow-lg"
+              onClick={downloadCsv}
+            >
+              {uiText[language].downloadCsv}
             </button>
 
             <button


### PR DESCRIPTION
## Summary
- add localized text for CSV download and email actions
- support exporting survey results as CSV
- add mailto helper for emailing results

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad648ed2688323a529dd169c50225f