### PR TITLE
Add navigation controls and progress bar to survey

### DIFF
--- a/src/GlobalMindednessSurvey.jsx
+++ b/src/GlobalMindednessSurvey.jsx
@@ -268,16 +268,24 @@ const uiText = {
     const [responses, setResponses] = useState(Array(questionCount).fill(null));
     const [currentQuestion, setCurrentQuestion] = useState(0);
     const [results, setResults] = useState(null);
-  
+
     const handleAnswer = (value) => {
       const updated = [...responses];
       updated[currentQuestion] = parseInt(value);
       setResponses(updated);
-  
+    };
+
+    const goBack = () => {
+      if (currentQuestion > 0) {
+        setCurrentQuestion(currentQuestion - 1);
+      }
+    };
+
+    const goNext = () => {
       if (currentQuestion < questionCount - 1) {
         setCurrentQuestion(currentQuestion + 1);
       } else {
-        calculateResults(updated);
+        calculateResults(responses);
       }
     };
   
@@ -461,6 +469,12 @@ const uiText = {
               <p className="mb-6 text-lg font-medium text-gray-700 text-center">
                 {uiText[language].question} {currentQuestion + 1} {uiText[language].of} {questionCount}
               </p>
+              <div className="w-full bg-gray-200 rounded-full h-2 mb-6">
+                <div
+                  className="bg-blue-600 h-2 rounded-full"
+                  style={{ width: `${((currentQuestion + 1) / questionCount) * 100}%` }}
+                ></div>
+              </div>
               <p className="mb-8 text-xl text-gray-800 text-center">{fullSurveyData.questions[language][currentQuestion]}</p>
               <div className="flex flex-col gap-4">
                 {fullSurveyData.scaleDescriptors[language].map((desc, idx) => (
@@ -472,6 +486,21 @@ const uiText = {
                     <strong>{idx + 1}:</strong> {desc}
                   </button>
                 ))}
+                <div className="flex justify-between mt-4">
+                  <button
+                    className="px-4 py-2 border rounded-2xl bg-white shadow disabled:opacity-50"
+                    onClick={goBack}
+                    disabled={currentQuestion === 0}
+                  >
+                    Back
+                  </button>
+                  <button
+                    className="px-4 py-2 border rounded-2xl bg-white shadow"
+                    onClick={goNext}
+                  >
+                    Next
+                  </button>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Store answers without auto-advancing and add navigation handlers for moving forward and backward through questions.
- Add a progress bar reflecting current position in survey and include Back/Next controls with disabling on first question.

## Testing
- `CI=true npm test --silent -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ad566dd2748323b34c0da84ea7bf9d