### PR TITLE
Add question progress bar to GlobalMindednessSurvey

### DIFF
--- a/src/GlobalMindednessSurvey.jsx
+++ b/src/GlobalMindednessSurvey.jsx
@@ -277,6 +277,7 @@ const uiText = {
     const [currentQuestion, setCurrentQuestion] = useState(0);
     const [results, setResults] = useState(null);
     const [participantName, setParticipantName] = useState('');
+    const progress = (currentQuestion + 1) / questionCount;
   
     const handleAnswer = (value) => {
       const updated = [...responses];
@@ -492,6 +493,12 @@ const uiText = {
               <p className="mb-6 text-lg font-medium text-gray-700 text-center">
                 {uiText[language].question} {currentQuestion + 1} {uiText[language].of} {questionCount}
               </p>
+              <div className="w-full bg-gray-200 rounded-full h-2 mb-4">
+                <div
+                  className="bg-blue-600 h-2 rounded-full transition-all"
+                  style={{ width: `${progress * 100}%` }}
+                ></div>
+              </div>
               <p className="mb-8 text-xl text-gray-800 text-center">{fullSurveyData.questions[language][currentQuestion]}</p>
               <div className="flex flex-col gap-4">
                 {fullSurveyData.scaleDescriptors[language].map((desc, idx) => (


### PR DESCRIPTION
## Summary
- compute survey progress from current question index
- display dynamic progress bar above questions

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ad6c83472883239cb79827a67d896e