### PR TITLE
Carry logo branding through the survey and results screens

### DIFF
--- a/src/GlobalMindednessSurvey.jsx
+++ b/src/GlobalMindednessSurvey.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { jsPDF } from "jspdf";
 import { fullSurveyData, uiText, facetEducation, getFacetBand } from "./surveyData";
+import Header from "./Header";
 import logo from "./assets/logo.png";
 
 const loadImage = (src) =>
@@ -289,22 +290,12 @@ const loadImage = (src) =>
   
     return (
       <div className="p-6 max-w-2xl mx-auto bg-white rounded-2xl shadow-xl mt-10 border border-gray-200">
-        <h1 className="text-4xl font-bold mb-6 text-center text-gray-800">{uiText[language].surveyTitle}</h1>
-        <div className="mb-6 text-center">
-          <select
-            className="border p-2 rounded"
-            value={language}
-            onChange={(e) => {
-              onLanguageChange(e.target.value);
-            }}
-          >
-            <option value="en">English</option>
-            <option value="zh">中文</option>
-            <option value="fr">Français</option>
-            <option value="es">Español</option>
-          </select>
-        </div>
-  
+        <Header
+          title={uiText[language].surveyTitle}
+          language={language}
+          onLanguageChange={onLanguageChange}
+        />
+
         {results ? (
           <div>
             <h2 className="text-2xl font-semibold mb-4 text-gray-700">{uiText[language].yourResults}</h2>

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import logo from './assets/logo.png';
+
+export default function Header({ title, language, onLanguageChange }) {
+  return (
+    <div className="flex items-center justify-between gap-4 mb-6 pb-4 border-b border-gray-100">
+      <div className="flex items-center gap-3 min-w-0">
+        <img src={logo} alt="" className="w-12 h-12 object-contain shrink-0" />
+        <h1 className="text-2xl sm:text-3xl font-bold text-gray-800 truncate">{title}</h1>
+      </div>
+      <select
+        className="border p-2 rounded shrink-0"
+        value={language}
+        onChange={(e) => onLanguageChange(e.target.value)}
+        aria-label="Language"
+      >
+        <option value="en">English</option>
+        <option value="zh">中文</option>
+        <option value="fr">Français</option>
+        <option value="es">Español</option>
+      </select>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,9 @@
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    @apply min-h-screen bg-gradient-to-b from-slate-100 via-blue-50 to-slate-100 pb-16;
+  }
+}


### PR DESCRIPTION
## Summary

- New shared `Header` component — logo, survey title, and the language selector in one row — used on both the question screens and the results screen, so the logo now appears throughout the app rather than only on the landing page. (The PDF header already carries the logo from #45.)
- Replaces the plain white page background with a soft slate→blue gradient for a bit more depth behind the white cards.

## Testing

- `react-scripts build` passes with `CI=true` (warnings as errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVFqKQZkaL5XyTjZH2FEj3

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVFqKQZkaL5XyTjZH2FEj3)_