### PR TITLE
Visual upgrade: radar chart, brand fonts and palette, micro-interactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "global-mindedness-survey-tailwind",
       "version": "1.0.0",
       "dependencies": {
+        "@fontsource/nunito-sans": "^5.3.0",
+        "@fontsource/outfit": "^5.3.0",
         "jspdf": "^2.5.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2451,6 +2453,24 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fontsource/nunito-sans": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/nunito-sans/-/nunito-sans-5.3.0.tgz",
+      "integrity": "sha512-CctNhebQ2YYJUwVMCAkHexQg7yedfz9s8JzaETALyc9QIQuDFRlNTWXux9H5PsNLgptPkrzRDomAdLJt1sDFpQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/outfit": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/outfit/-/outfit-5.3.0.tgz",
+      "integrity": "sha512-0AVHzTTVJSxWDOxPKSfMeHhZeBFDU3cmgrcOb76ZEyhGo0+xgyG3GsLF3h9+X8w0IX7G4jzjJgFQEBiWdX6VgA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
+    "@fontsource/nunito-sans": "^5.3.0",
+    "@fontsource/outfit": "^5.3.0",
     "jspdf": "^2.5.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/GlobalMindednessSurvey.jsx
+++ b/src/GlobalMindednessSurvey.jsx
@@ -1,8 +1,30 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { jsPDF } from "jspdf";
 import { fullSurveyData, uiText, facetEducation, getFacetBand } from "./surveyData";
 import Header from "./Header";
+import RadarChart from "./RadarChart";
 import logo from "./assets/logo.png";
+
+const useCountUp = (target, duration = 900) => {
+  const [value, setValue] = useState(target);
+  useEffect(() => {
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      setValue(target);
+      return undefined;
+    }
+    let raf;
+    const start = performance.now();
+    const tick = (now) => {
+      const t = Math.min((now - start) / duration, 1);
+      const eased = 1 - Math.pow(1 - t, 3);
+      setValue(Math.round(target * eased));
+      if (t < 1) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [target, duration]);
+  return value;
+};
 
 const loadImage = (src) =>
   new Promise((resolve, reject) => {
@@ -20,6 +42,7 @@ const loadImage = (src) =>
     const [participantName, setParticipantName] = useState('');
     const [copied, setCopied] = useState(false);
     const progress = (currentQuestion + 1) / questionCount;
+    const displayScore = useCountUp(results ? results.overallScore : 0);
 
     const shareUrl = `${window.location.origin}${window.location.pathname}`;
 
@@ -177,7 +200,7 @@ const loadImage = (src) =>
       };
 
       let y = headerHeight + 20;
-      const overallCardHeight = 120;
+      const overallCardHeight = 170;
       doc.setFillColor(255, 255, 255);
       doc.setDrawColor(...palette.border);
       doc.roundedRect(margin, y, contentWidth, overallCardHeight, 16, 16, 'FD');
@@ -185,27 +208,76 @@ const loadImage = (src) =>
       doc.setFont('helvetica', 'bold');
       doc.setFontSize(16);
       doc.setTextColor(...palette.primary);
-      doc.text(uiText[pdfLang].overallScore, margin + 24, y + 34);
+      doc.text(uiText[pdfLang].overallScore, margin + 24, y + 44);
 
       doc.setFontSize(30);
-      doc.text(`${results.overallScore}`, margin + 24, y + 74);
+      doc.text(`${results.overallScore}`, margin + 24, y + 84);
       doc.setFont('helvetica', 'normal');
       doc.setFontSize(12);
       doc.setTextColor(...palette.muted);
       doc.text(
         `/ ${results.overallMax}  •  ${uiText[pdfLang].interpretations[results.interpretationKey]}`,
         margin + 90,
-        y + 74
+        y + 84
       );
 
+      const radarZoneWidth = 280;
       drawProgressBar(
         margin + 24,
-        y + 88,
-        contentWidth - 48,
+        y + 108,
+        contentWidth - 48 - radarZoneWidth,
         12,
         overallPercent,
         palette.accent
       );
+
+      // Facet radar on the right of the overall card.
+      const drawPolygon = (pts, style) => {
+        const segments = [];
+        for (let i = 1; i < pts.length; i += 1) {
+          segments.push([pts[i][0] - pts[i - 1][0], pts[i][1] - pts[i - 1][1]]);
+        }
+        doc.lines(segments, pts[0][0], pts[0][1], [1, 1], style, true);
+      };
+      const radarCats = Object.keys(fullSurveyData.categories);
+      const radarCx = margin + contentWidth - radarZoneWidth / 2 - 10;
+      const radarCy = y + overallCardHeight / 2;
+      const radarR = 48;
+      const radarPoint = (i, fraction) => {
+        const angle = -Math.PI / 2 + (i * 2 * Math.PI) / radarCats.length;
+        return [radarCx + Math.cos(angle) * radarR * fraction, radarCy + Math.sin(angle) * radarR * fraction];
+      };
+      doc.setDrawColor(...palette.border);
+      doc.setLineWidth(0.8);
+      [0.25, 0.5, 0.75, 1].forEach((fraction) => {
+        drawPolygon(radarCats.map((_, i) => radarPoint(i, fraction)), 'S');
+      });
+      radarCats.forEach((_, i) => {
+        const [px, py] = radarPoint(i, 1);
+        doc.line(radarCx, radarCy, px, py);
+      });
+      doc.setFillColor(214, 229, 236);
+      doc.setDrawColor(46, 113, 145);
+      doc.setLineWidth(1.5);
+      drawPolygon(
+        radarCats.map((category, i) =>
+          radarPoint(i, results.categoryScores[category] / results.categoryScores[`${category}Max`])
+        ),
+        'FD'
+      );
+      doc.setFont('helvetica', 'bold');
+      doc.setFontSize(7);
+      doc.setTextColor(71, 85, 105);
+      radarCats.forEach((category, i) => {
+        const angle = -Math.PI / 2 + (i * 2 * Math.PI) / radarCats.length;
+        const cos = Math.cos(angle);
+        const sin = Math.sin(angle);
+        const lx = radarCx + cos * (radarR + 8);
+        const ly = radarCy + sin * (radarR + 8) + (sin > 0.3 ? 8 : sin < -0.3 ? -4 : 2);
+        const align = Math.abs(cos) < 0.3 ? 'center' : cos > 0 ? 'left' : 'right';
+        doc.text(fullSurveyData.categoryLabels[pdfLang][category], lx, ly, { align });
+      });
+      doc.setLineWidth(1);
 
       y += overallCardHeight + 24;
       doc.setFont('helvetica', 'bold');
@@ -218,12 +290,14 @@ const loadImage = (src) =>
       const categoryOrder = Object.keys(fullSurveyData.categories);
       const cardWidth = (contentWidth - gap * (categoryOrder.length - 1)) / categoryOrder.length;
       const cardHeight = 200;
+      // Categorical order validated for color-vision-deficiency separation:
+      // violet sits between emerald and pink.
       const categoryColors = [
         [59, 130, 246],
         [245, 158, 11],
         [16, 185, 129],
-        [236, 72, 153],
         [139, 92, 246],
+        [236, 72, 153],
       ];
 
       categoryOrder.forEach((category, index) => {
@@ -300,15 +374,23 @@ const loadImage = (src) =>
           <div>
             <h2 className="text-2xl font-semibold mb-4 text-gray-700">{uiText[language].yourResults}</h2>
             <p className="text-lg mb-4 text-gray-600">
-              {uiText[language].overallScore}: <strong>{results.overallScore} / {results.overallMax}</strong> ({uiText[language].interpretations[results.interpretationKey]})
+              {uiText[language].overallScore}: <strong>{displayScore} / {results.overallMax}</strong> ({uiText[language].interpretations[results.interpretationKey]})
             </p>
             <div className="w-full bg-gray-200 rounded-full h-5 mb-8">
               <div
-                className="bg-blue-600 h-5 rounded-full transition-all"
-                style={{ width: `${(results.overallScore / results.overallMax) * 100}%` }}
+                className="bg-brand-gold h-5 rounded-full transition-all duration-500 ease-out"
+                style={{ width: `${(displayScore / results.overallMax) * 100}%` }}
               ></div>
             </div>
-  
+
+            <RadarChart
+              title={uiText[language].categoryScores}
+              data={Object.keys(fullSurveyData.categories).map((category) => ({
+                label: fullSurveyData.categoryLabels[language][category],
+                value: results.categoryScores[category] / results.categoryScores[`${category}Max`],
+              }))}
+            />
+
             <div className="mt-6">
               <h3 className="text-xl font-semibold mb-4 text-gray-700">{uiText[language].categoryScores}</h3>
               <ul className="space-y-6">
@@ -322,14 +404,14 @@ const loadImage = (src) =>
                     <li key={category} className="border rounded-2xl p-4 bg-gray-50">
                       <p className="mb-1 text-gray-700">
                         <strong>{fullSurveyData.categoryLabels[language][category]}:</strong> {score} / {max}
-                        <span className="ml-2 text-sm font-semibold text-blue-700">
+                        <span className="ml-2 text-sm font-semibold text-brand-ocean">
                           {uiText[language].bandNames[band]}
                         </span>
                       </p>
                       <p className="mb-2 text-sm text-gray-500 italic">{fullSurveyData.categoryDescriptions[language][category]}</p>
                       <div className="w-full bg-gray-200 rounded-full h-4 mb-3">
                         <div
-                          className="bg-green-500 h-4 rounded-full transition-all"
+                          className="bg-brand-ocean h-4 rounded-full transition-all duration-500 ease-out"
                           style={{ width: `${percentage}%` }}
                         ></div>
                       </div>
@@ -364,7 +446,7 @@ const loadImage = (src) =>
               />
             </div>
             <button
-              className="mt-6 w-full bg-green-600 hover:bg-green-700 text-white text-xl py-3 rounded-2xl shadow-lg"
+              className="mt-6 w-full bg-brand-leaf hover:bg-brand-leafdark text-white text-xl py-3 rounded-2xl shadow-lg"
               onClick={downloadPdf}
             >
               {uiText[language].downloadPdf}
@@ -375,7 +457,7 @@ const loadImage = (src) =>
               <div className="flex flex-wrap gap-2">
                 {typeof navigator !== 'undefined' && navigator.share && (
                   <button
-                    className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-full shadow"
+                    className="px-4 py-2 bg-brand-ocean hover:bg-brand-oceandark text-white rounded-full shadow"
                     onClick={handleNativeShare}
                   >
                     {uiText[language].shareButton}
@@ -423,7 +505,7 @@ const loadImage = (src) =>
             </div>
 
             <button
-              className="mt-10 w-full bg-blue-600 hover:bg-blue-700 text-white text-xl py-3 rounded-2xl shadow-lg"
+              className="mt-10 w-full bg-brand-ocean hover:bg-brand-oceandark text-white text-xl py-3 rounded-2xl shadow-lg"
               onClick={() => {
                 setResults(null);
                 setResponses(Array(questionCount).fill(null));
@@ -435,13 +517,13 @@ const loadImage = (src) =>
           </div>
         ) : (
           <div className="space-y-8">
-            <div className="border rounded-2xl p-8 shadow-lg bg-gray-50">
+            <div key={currentQuestion} className="border rounded-2xl p-8 shadow-lg bg-gray-50 animate-fade-slide motion-reduce:animate-none">
               <p className="mb-6 text-lg font-medium text-gray-700 text-center">
                 {uiText[language].question} {currentQuestion + 1} {uiText[language].of} {questionCount}
               </p>
               <div className="w-full bg-gray-200 rounded-full h-2 mb-4">
                 <div
-                  className="bg-blue-600 h-2 rounded-full transition-all"
+                  className="bg-brand-ocean h-2 rounded-full transition-all duration-500 ease-out"
                   style={{ width: `${progress * 100}%` }}
                 ></div>
               </div>
@@ -452,9 +534,9 @@ const loadImage = (src) =>
                   return (
                     <button
                       key={idx + 1}
-                      className={`px-6 py-4 text-lg border rounded-2xl hover:bg-blue-100 shadow font-medium transition-all w-full text-left ${
+                      className={`px-6 py-4 text-lg border rounded-2xl hover:bg-brand-mist hover:shadow-md hover:-translate-y-0.5 motion-reduce:hover:translate-y-0 shadow font-medium transition-all w-full text-left ${
                         selected
-                          ? 'bg-blue-50 border-blue-600 ring-2 ring-blue-500 text-blue-800'
+                          ? 'bg-brand-mist border-brand-ocean ring-2 ring-brand-ocean text-brand-oceandark'
                           : 'bg-white text-gray-700'
                       }`}
                       onClick={() => handleAnswer(idx + 1)}

--- a/src/LandingPage.jsx
+++ b/src/LandingPage.jsx
@@ -41,7 +41,7 @@ export default function LandingPage({ language, onLanguageChange, onStart }) {
       </details>
 
       <button
-        className="bg-blue-600 hover:bg-blue-700 text-white text-xl py-3 px-8 rounded-2xl shadow-lg"
+        className="bg-brand-ocean hover:bg-brand-oceandark text-white text-xl py-3 px-8 rounded-2xl shadow-lg"
         onClick={onStart}
       >
         {text.startButton}

--- a/src/RadarChart.jsx
+++ b/src/RadarChart.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+
+const CX = 230;
+const CY = 155;
+const R = 98;
+const LABEL_R = 118;
+
+const pointAt = (index, count, fraction) => {
+  const angle = -Math.PI / 2 + (index * 2 * Math.PI) / count;
+  return [CX + Math.cos(angle) * R * fraction, CY + Math.sin(angle) * R * fraction];
+};
+
+const toPolygon = (points) => points.map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`).join(' ');
+
+// Splits a label onto two lines at the space nearest its middle.
+const splitLabel = (label) => {
+  if (label.length <= 14 || !label.includes(' ')) return [label];
+  const mid = label.length / 2;
+  let best = -1;
+  for (let i = 0; i < label.length; i += 1) {
+    if (label[i] === ' ' && (best === -1 || Math.abs(i - mid) < Math.abs(best - mid))) best = i;
+  }
+  return [label.slice(0, best), label.slice(best + 1)];
+};
+
+export default function RadarChart({ data, title }) {
+  const count = data.length;
+  const gridLevels = [0.25, 0.5, 0.75, 1];
+
+  return (
+    <svg
+      viewBox="0 0 460 310"
+      role="img"
+      aria-label={title}
+      className="w-full max-w-md mx-auto animate-fade-in motion-reduce:animate-none"
+    >
+      <title>{title}</title>
+      {gridLevels.map((level) => (
+        <polygon
+          key={level}
+          points={toPolygon(data.map((_, i) => pointAt(i, count, level)))}
+          fill="none"
+          stroke="#E2E8F0"
+          strokeWidth="1"
+        />
+      ))}
+      {data.map((_, i) => {
+        const [x, y] = pointAt(i, count, 1);
+        return <line key={i} x1={CX} y1={CY} x2={x} y2={y} stroke="#E2E8F0" strokeWidth="1" />;
+      })}
+
+      <polygon
+        points={toPolygon(data.map((d, i) => pointAt(i, count, d.value)))}
+        fill="#2E7191"
+        fillOpacity="0.15"
+        stroke="#2E7191"
+        strokeWidth="2"
+        strokeLinejoin="round"
+      />
+
+      {data.map((d, i) => {
+        const [x, y] = pointAt(i, count, d.value);
+        return (
+          <g key={d.label}>
+            <circle cx={x} cy={y} r="4" fill="#2E7191" />
+            <circle cx={x} cy={y} r="12" fill="transparent">
+              <title>{`${d.label}: ${Math.round(d.value * 100)}%`}</title>
+            </circle>
+          </g>
+        );
+      })}
+
+      {data.map((d, i) => {
+        const angle = -Math.PI / 2 + (i * 2 * Math.PI) / count;
+        const x = CX + Math.cos(angle) * LABEL_R;
+        const y = CY + Math.sin(angle) * LABEL_R;
+        const cos = Math.cos(angle);
+        const anchor = Math.abs(cos) < 0.3 ? 'middle' : cos > 0 ? 'start' : 'end';
+        const lines = splitLabel(d.label);
+        const firstDy = y > CY + 10 ? 10 : lines.length > 1 ? -6 : 4;
+        return (
+          <text
+            key={d.label}
+            x={x}
+            y={y}
+            textAnchor={anchor}
+            fontSize="11"
+            fill="#475569"
+            fontWeight="600"
+          >
+            {lines.map((line, lineIdx) => (
+              <tspan key={lineIdx} x={x} dy={lineIdx === 0 ? firstDy : 12}>
+                {line}
+              </tspan>
+            ))}
+          </text>
+        );
+      })}
+    </svg>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,9 @@
 
 @layer base {
   body {
-    @apply min-h-screen bg-gradient-to-b from-slate-100 via-blue-50 to-slate-100 pb-16;
+    @apply min-h-screen bg-gradient-to-b from-slate-100 via-blue-50 to-slate-100 pb-16 font-sans text-brand-ink;
+  }
+  h1, h2, h3 {
+    @apply font-display;
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import '@fontsource/outfit/600.css';
+import '@fontsource/outfit/700.css';
+import '@fontsource/nunito-sans/400.css';
+import '@fontsource/nunito-sans/600.css';
+import '@fontsource/nunito-sans/700.css';
 import './index.css';
 import App from './App';
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,40 @@
+const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {
   content: ["./src/**/*.{js,jsx,ts,tsx}", "./public/index.html"],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        // Palette sampled from the GMS logo: globe blue, leaf green, gold
+        brand: {
+          ocean: '#2E7191',
+          oceandark: '#245C78',
+          leaf: '#4C8451',
+          leafdark: '#3E6C42',
+          gold: '#ECAD2D',
+          ink: '#28323C',
+          mist: '#EEF4F7',
+        },
+      },
+      fontFamily: {
+        sans: ['"Nunito Sans"', ...defaultTheme.fontFamily.sans],
+        display: ['Outfit', ...defaultTheme.fontFamily.sans],
+      },
+      keyframes: {
+        'fade-slide': {
+          '0%': { opacity: '0', transform: 'translateY(12px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
+        'fade-in': {
+          '0%': { opacity: '0' },
+          '100%': { opacity: '1' },
+        },
+      },
+      animation: {
+        'fade-slide': 'fade-slide 0.3s ease-out both',
+        'fade-in': 'fade-in 0.5s ease-out both',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary

Implements the four approved aesthetic upgrades:

1. **Five-facet radar chart** — an inline-SVG pentagon on the results screen showing the score profile at a glance: recessive gridlines, single brand-color series, localized facet labels (auto-wrapped), and native tooltips with exact percentages on each vertex. A matching radar is drawn beside the overall score in the PDF report.
2. **Font pairing** — self-hosted via Fontsource (no external requests): **Outfit** for headings, **Nunito Sans** for body text.
3. **Brand color system** — palette sampled from the actual logo (ocean `#2E7191`, leaf `#4C8451`, gold `#ECAD2D`, ink, mist) defined once in `tailwind.config.js` and applied consistently to buttons, progress bars, selection states, and accents on web and PDF. The five facet identity colors were re-ordered (violet now sits between emerald and pink) after a color-vision-deficiency check flagged the old emerald↔pink adjacency as indistinguishable under deuteranopia.
4. **Micro-interactions** — question cards slide-fade in on each question, progress bars ease over 500 ms, answer buttons lift on hover, and the overall score counts up on reveal. All animations honor `prefers-reduced-motion`.

## Testing

- `react-scripts build` passes with `CI=true` (warnings as errors).
- Headless-browser click-through of all 30 questions; screenshots verified of the landing page, question screen, and full results screen — including a radar label-clipping bug found and fixed this way (wide labels like "Interconnectedness" overflowed the original viewBox).
- Facet palette validated programmatically for CVD separation, lightness, chroma, and contrast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVFqKQZkaL5XyTjZH2FEj3

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVFqKQZkaL5XyTjZH2FEj3)_